### PR TITLE
Fix exception on unknown repository

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -87,12 +87,17 @@ const getSoupDataForPackage = (soupName, soupVersion) => __awaiter(void 0, void 
     var _a, _b;
     const soupDataResponse = yield (0, node_fetch_1.default)(`https://registry.npmjs.org/${soupName}`);
     const soupData = (yield soupDataResponse.json());
-    const versionSpecificSoupData = soupData === null || soupData === void 0 ? void 0 : soupData.versions[soupVersion.replace(/[^\d.-]/g, '')];
     let soupLanguages = 'unknown';
-    if ((_b = (_a = versionSpecificSoupData === null || versionSpecificSoupData === void 0 ? void 0 : versionSpecificSoupData.repository) === null || _a === void 0 ? void 0 : _a.url) === null || _b === void 0 ? void 0 : _b.includes('github')) {
-        soupLanguages = yield getSoupLanguageData(versionSpecificSoupData.repository.url);
+    let soupSite = 'private repo';
+    if (soupData === null || soupData === void 0 ? void 0 : soupData.versions) {
+        const versionSpecificSoupData = soupData === null || soupData === void 0 ? void 0 : soupData.versions[soupVersion.replace(/[^\d.-]/g, '')];
+        if ((_b = (_a = versionSpecificSoupData === null || versionSpecificSoupData === void 0 ? void 0 : versionSpecificSoupData.repository) === null || _a === void 0 ? void 0 : _a.url) === null || _b === void 0 ? void 0 : _b.includes('github')) {
+            soupLanguages = yield getSoupLanguageData(versionSpecificSoupData.repository.url);
+        }
+        soupSite =
+            (versionSpecificSoupData === null || versionSpecificSoupData === void 0 ? void 0 : versionSpecificSoupData.homepage) ||
+                versionSpecificSoupData.repository.url;
     }
-    const soupSite = versionSpecificSoupData === null || versionSpecificSoupData === void 0 ? void 0 : versionSpecificSoupData.homepage;
     tableContents.push(`| ${soupName} | ${soupLanguages} | ${soupSite} | ${soupVersion} | ${DEFAULT_RISK_LEVEL} | ${DEFAULT_VERIFICATION} |`);
 });
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,18 +72,24 @@ const getSoupLanguageData = async (soupRepoUrl: string) => {
 const getSoupDataForPackage = async (soupName: string, soupVersion: string) => {
   const soupDataResponse = await fetch(`https://registry.npmjs.org/${soupName}`)
   const soupData = (await soupDataResponse.json()) as TNpmData
-  const versionSpecificSoupData =
-    soupData?.versions[soupVersion.replace(/[^\d.-]/g, '')]
 
   let soupLanguages = 'unknown'
+  let soupSite = 'private repo'
 
-  if (versionSpecificSoupData?.repository?.url?.includes('github')) {
-    soupLanguages = await getSoupLanguageData(
+  if (soupData?.versions) {
+    const versionSpecificSoupData =
+      soupData?.versions[soupVersion.replace(/[^\d.-]/g, '')]
+
+    if (versionSpecificSoupData?.repository?.url?.includes('github')) {
+      soupLanguages = await getSoupLanguageData(
+        versionSpecificSoupData.repository.url
+      )
+    }
+
+    soupSite =
+      versionSpecificSoupData?.homepage ||
       versionSpecificSoupData.repository.url
-    )
   }
-
-  const soupSite = versionSpecificSoupData?.homepage
 
   tableContents.push(
     `| ${soupName} | ${soupLanguages} | ${soupSite} | ${soupVersion} | ${DEFAULT_RISK_LEVEL} | ${DEFAULT_VERIFICATION} |`


### PR DESCRIPTION
![Unknown](https://media.giphy.com/media/cQPQy29ONzKs7E8nWp/giphy-downsized.gif)

## Reason for this change

We guarded against a repository not returning the right information, but *not* against a dependency not having a repository registration on NPM at all. This is of course the case for private dependencies. This change will fall back to 'private repo' for packages that are not registered on NPM and will fall back to the repo url if there is no homepage registered.

## Impact of this change on existing projects

Rows with a `homepage` entry of `undefined` may change to the repo url after this change.