### PR TITLE
Update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,16 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
-  "labels": ["dependencies"]
+  "extends": ["config:base", "schedule:monthly"],
+  "rangeStrategy": "pin",
+  "timezone": "Europe/Amsterdam",
+  "enabledManagers": ["npm", "github-actions"],
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "groupName": "Combine and automerge all non-major updates",
+      "matchPackagePatterns": ["*"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
+    }
+  ]
 }


### PR DESCRIPTION
![Renovation](https://media.giphy.com/media/xZsLh7B3KMMyUptD9D/giphy.gif)

## Reason for this change

Renovate updates are scheduled on a high frequency, which doesn't fit a project that is not in active development. This configuration change will allow us to review and merge all minor updates in one go once a month. Major updates will still be created separately for review.
