### PR TITLE
Add intro and soup count

### DIFF
--- a/SOUP.md
+++ b/SOUP.md
@@ -1,3 +1,9 @@
+# SOUP Register
+
+This document contains a list of all SOUP (Software of Unknown Provenance) dependencies used in this repository. SOUP is third-party software that is included in the project and is not developed by the project team. The SOUP dependencies are listed below, along with their programming languages, website, version, risk level, and verification of reasoning.
+
+The repository uses a total of 4 unique SOUP dependencies.
+
 ## generate-soup-register
 
 | Package Name     | Programming Languages | Website                                                      | Version | Risk Level | Verification of Reasoning               |

--- a/dist/index.js
+++ b/dist/index.js
@@ -163,6 +163,29 @@ const getSoupDataForPackageCollection = (packageJSON) => __awaiter(void 0, void 
     return header + table;
 });
 /**
+ * Method to generate a list of unique dependencies from a list of package.json contents.
+ * @param packageJSONs TPackageJson[]: the contents of one or more package JSON to generate a unique list of names
+ */
+const getUniqueDependencies = (packageJSONs) => {
+    const dependencies = new Set();
+    packageJSONs.forEach((packageJSON) => {
+        if (packageJSON.dependencies) {
+            Object.keys(packageJSON.dependencies).forEach((dependency) => dependencies.add(dependency));
+        }
+    });
+    return [...dependencies];
+};
+/**
+ * Method to generate a header and intro for the SOUP register
+ * @param packageJSONs TPackageJson[]: the contents of one or more package JSON to generate a unique list of names
+ */
+const generateSoupHeader = (packageJSONs) => {
+    const header = `# SOUP Register`;
+    const dependenciesCount = getUniqueDependencies(packageJSONs).length;
+    const intro = `This document contains a list of all SOUP (Software of Unknown Provenance) dependencies used in this repository. SOUP is third-party software that is included in the project and is not developed by the project team. The SOUP dependencies are listed below, along with their programming languages, website, version, risk level, and verification of reasoning.\n\nThe repository uses a total of ${dependenciesCount} unique SOUP dependencies.`;
+    return `${header}\n\n${intro}\n\n`;
+};
+/**
  * Main generator method: calls the other methods and combines their output in MD format and stores it in SOUP.md
  */
 const generateSoupRegister = () => __awaiter(void 0, void 0, void 0, function* () {
@@ -185,7 +208,8 @@ const generateSoupRegister = () => __awaiter(void 0, void 0, void 0, function* (
     const repositorySoupRequests = [];
     packageJSONs.forEach((packageJson) => repositorySoupRequests.push(getSoupDataForPackageCollection(packageJson)));
     const soupData = yield Promise.all(repositorySoupRequests);
-    const soupRegister = soupData.join('\n\n');
+    const soupHeader = generateSoupHeader(packageJSONs);
+    const soupRegister = soupHeader + soupData.join('\n\n');
     core.info(`✅ SOUP data retrieved`);
     // Write SOUP file
     yield node_fs_1.default.writeFile(soupPath, soupRegister, { encoding: 'utf8', flag: 'w' }, (error) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -182,6 +182,38 @@ const getSoupDataForPackageCollection = async (packageJSON: TPackageJson) => {
 }
 
 /**
+ * Method to generate a list of unique dependencies from a list of package.json contents.
+ * @param packageJSONs TPackageJson[]: the contents of one or more package JSON to generate a unique list of names
+ */
+const getUniqueDependencies = (packageJSONs: TPackageJson[]) => {
+  const dependencies = new Set<string>()
+
+  packageJSONs.forEach((packageJSON) => {
+    if (packageJSON.dependencies) {
+      Object.keys(packageJSON.dependencies).forEach((dependency) =>
+        dependencies.add(dependency)
+      )
+    }
+  })
+
+  return [...dependencies]
+}
+
+/**
+ * Method to generate a header and intro for the SOUP register
+ * @param packageJSONs TPackageJson[]: the contents of one or more package JSON to generate a unique list of names
+ */
+const generateSoupHeader = (packageJSONs: TPackageJson[]) => {
+  const header = `# SOUP Register`
+
+  const dependenciesCount = getUniqueDependencies(packageJSONs).length
+
+  const intro = `This document contains a list of all SOUP (Software of Unknown Provenance) dependencies used in this repository. SOUP is third-party software that is included in the project and is not developed by the project team. The SOUP dependencies are listed below, along with their programming languages, website, version, risk level, and verification of reasoning.\n\nThe repository uses a total of ${dependenciesCount} unique SOUP dependencies.`
+
+  return `${header}\n\n${intro}\n\n`
+}
+
+/**
  * Main generator method: calls the other methods and combines their output in MD format and stores it in SOUP.md
  */
 const generateSoupRegister = async () => {
@@ -213,7 +245,9 @@ const generateSoupRegister = async () => {
 
   const soupData = await Promise.all(repositorySoupRequests)
 
-  const soupRegister = soupData.join('\n\n')
+  const soupHeader = generateSoupHeader(packageJSONs)
+
+  const soupRegister = soupHeader + soupData.join('\n\n')
 
   core.info(`✅ SOUP data retrieved`)
 


### PR DESCRIPTION
![No formal record of how many](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExdzRqZ2FlemE0ZTVuMWZtc3htM3I4dzVkcDhkaTdyN2J0czU0azdldiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/ggPkv80THJWn9cZt0a/giphy-downsized.gif)

## Reason for this change

We recently got asked to estimate the number of SOUP dependencies in our projects. Counting the rows in the register is not hard, but becomes time-consuming when done in a big mono-repo consisting of multiple projects. Especially if those projects have duplicate dependencies between them.

This PR adds a header and intro paragraph to the SOUP register (to give the file more context) and inserts a count of unique dependencies (by name) in the whole repository.

## Impact of this change on existing projects

Existing SOUP registers will be updated with a header, intro and unique SOUP count.
