### PR TITLE
Catch bad urls

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,29 +54,33 @@ const octokit = new Octokit({ auth, request: { fetch } })
  * @returns string: comma separated languages that make up at least 10% of the project
  */
 const getSoupLanguageData = async (soupRepoUrl: string) => {
-  const { owner, name } = parseGithubUrl(soupRepoUrl) ?? {}
-  if (!owner || !name) return 'unknown'
+  try {
+    const { owner, name } = parseGithubUrl(soupRepoUrl) ?? {}
+    if (!owner || !name) return 'unknown'
 
-  const soupLanguagesGitHubResponse = await octokit.request(
-    'GET /repos/{owner}/{name}/languages',
-    { owner, name }
-  )
-
-  if (soupLanguagesGitHubResponse.status !== 200) return 'unknown'
-  const soupLanguagesData = soupLanguagesGitHubResponse.data as Record<
-    string,
-    number
-  >
-
-  const totalSoupBytes =
-    Object.values(soupLanguagesData)?.reduce((a, b) => a + b, 0) ?? 0
-
-  return Object.keys(soupLanguagesData)
-    .filter(
-      // By filtering out languages that make up less than 10% we prevent listing unrelevant tool languages etc.
-      (language) => soupLanguagesData[language] > totalSoupBytes * 0.1
+    const soupLanguagesGitHubResponse = await octokit.request(
+      'GET /repos/{owner}/{name}/languages',
+      { owner, name }
     )
-    .join(', ')
+
+    if (soupLanguagesGitHubResponse.status !== 200) return 'unknown'
+    const soupLanguagesData = soupLanguagesGitHubResponse.data as Record<
+      string,
+      number
+    >
+
+    const totalSoupBytes =
+      Object.values(soupLanguagesData)?.reduce((a, b) => a + b, 0) ?? 0
+
+    return Object.keys(soupLanguagesData)
+      .filter(
+        // By filtering out languages that make up less than 10% we prevent listing unrelevant tool languages etc.
+        (language) => soupLanguagesData[language] > totalSoupBytes * 0.1
+      )
+      .join(', ')
+  } catch {
+    return 'unknown'
+  }
 }
 
 /**


### PR DESCRIPTION
![Just ignore them](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExeXkwanh0NGZrdG9lemhud3c4cTJzM25qOWcydWNqcXVpYTh0YTJ6biZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/W4YSYyB4zdU8wgcnNu/giphy-downsized.gif)

## Reason for this change

When a dependency declares a GitHub url on NPM, we will try to construct a repo url from that url and use it to fetch the (programming) language information. If that url is invalid, that will terminate the action and result in failure.

With this change, instead of breaking we will try to get the language information but catch any error and return `unknown` instead. (Which we would also do if we had no url or if the url would return no valid answer)

## Impact of this change on existing projects

None, only that those where the action failed because of this edge case should now pass (with "unknown" filled for the dependencies with broken urls).
